### PR TITLE
Basic health regen bar implementation

### DIFF
--- a/Assets/Dungeon/HealthPickup.cs
+++ b/Assets/Dungeon/HealthPickup.cs
@@ -16,13 +16,13 @@ public class HealthPickup : MonoBehaviour
         }
 
         //If player is at full health
-        if (player.currentHP == player.maxHP)
+        if (player.currentHP >= player.maxHP)
         {
             return; //Player at full health
         }
 
         //Update player health
-        player.currentHP = Math.Min(player.currentHP + health, player.maxHP);
+        player.ReplenishHealth(health);
 
         //Destory health pickup
         GameObject.Destroy(transform.gameObject);

--- a/Assets/Entity/EntityStats.cs
+++ b/Assets/Entity/EntityStats.cs
@@ -50,6 +50,10 @@ public class EntityStats : MonoBehaviour
             GetComponent<EnemyStats>().enemyDamageReturnCall();
         }
     }
+    public void ReplenishHealth(float amount) {
+        this.currentHP = Mathf.Min(this.currentHP + amount, this.maxHP);
+        updateHealthBar();
+    }
 
     //Return true if results in death
     public bool TakeDamage(float amount, EntityStats source)
@@ -72,13 +76,16 @@ public class EntityStats : MonoBehaviour
                 source.OnKill(this);
             }
         }
+        updateHealthBar();
+
+        return died;
+    }
+
+    private void updateHealthBar() {
         if (healthbar != null)
         {
             healthbar.value = currentHP / maxHP;
         }
-
-        return died;
-
     }
 
     public void AddAttribute(EntityAttribute attr, EntityStats source)

--- a/Assets/Entity/Player/PlayerStats.cs
+++ b/Assets/Entity/Player/PlayerStats.cs
@@ -11,6 +11,8 @@ public class PlayerStats : EntityStats
     public int[] baitTypes = { 0, 0, 0, 0 };
     public Text[] baitText;
 
+    public GameObject healthPickupGameObj;
+
     PlayerBase pbase;
     WeaponInventory weaponInv;
     public const float baseMovementSpeed = 10;
@@ -23,6 +25,8 @@ public class PlayerStats : EntityStats
     public float staminaRechargeRate = 2f;
     public Slider staminaBar;
     public Slider ammoBar;
+    public float killRegen; // goes zero to one
+    public Slider killRegenBar;
     public int ammo {get; private set;}
     public int maxAmmo {get; private set;}
     private float timeSinceLastTick = 0;
@@ -41,6 +45,23 @@ public class PlayerStats : EntityStats
         this.ammo = max;
         this.maxAmmo = max;
     }
+
+    public void increaseKillRegen(float amount) {
+        this.killRegen = Mathf.Min(this.killRegen + amount, 1f);
+        if (killRegen == 1f) {
+            useKillRegen();
+        }
+    }
+
+    public void useKillRegen() {
+        this.killRegen = 0f;
+
+        var pickupObj = Instantiate(healthPickupGameObj);
+        pickupObj.GetComponent<HealthPickup>().health = this.maxHP * 0.25f;
+
+        pickupObj.transform.position = transform.position;
+    }
+
 
     private void Start()
     {
@@ -63,6 +84,7 @@ public class PlayerStats : EntityStats
     {
         StatUpdate();
         staminaBar.value = stamina / staminaMax;
+        killRegenBar.value = killRegen;
         if(Time.time > timeSinceLastTick + timeBetweenTicks)
         {
             timeSinceLastTick = Time.time;
@@ -72,6 +94,7 @@ public class PlayerStats : EntityStats
             ammoBar.value = (float)ammo / (float)maxAmmo;
         }
     }
+
 
     public void UseStamina(float staminaCost)
     {
@@ -87,9 +110,9 @@ public class PlayerStats : EntityStats
 
     public override void OnKill(EntityStats victim)
     {
-
         weaponInv?.OnKill(victim);
         pbase.OnKill(victim);
+        increaseKillRegen(0.6f);
     }
 
     //Fishing Methods

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,5 +1,279 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &849168558451191946
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 849168558451191947}
+  - component: {fileID: 849168558451191945}
+  - component: {fileID: 849168558451191944}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &849168558451191947
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168558451191946}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 849168559055727073}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &849168558451191945
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168558451191946}
+  m_CullTransparentMesh: 0
+--- !u!114 &849168558451191944
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168558451191946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &849168559055727072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 849168559055727073}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &849168559055727073
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168559055727072}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 849168558451191947}
+  m_Father: {fileID: 849168559200411071}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &849168559200411070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 849168559200411071}
+  - component: {fileID: 849168559200411068}
+  m_Layer: 5
+  m_Name: Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &849168559200411071
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168559200411070}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.004, y: 0.004, z: 0.004}
+  m_Children:
+  - {fileID: 849168560106988682}
+  - {fileID: 849168559055727073}
+  m_Father: {fileID: 6934483369034327977}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.1}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &849168559200411068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168559200411070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 849168558451191947}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &849168560106988693
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 849168560106988682}
+  - component: {fileID: 849168560106988680}
+  - component: {fileID: 849168560106988683}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &849168560106988682
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168560106988693}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 849168559200411071}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &849168560106988680
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168560106988693}
+  m_CullTransparentMesh: 0
+--- !u!114 &849168560106988683
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849168560106988693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &941446159821267724
 GameObject:
   m_ObjectHideFlags: 0
@@ -33,6 +307,7 @@ RectTransform:
   - {fileID: 4197716345853168967}
   - {fileID: 1363825708522313754}
   - {fileID: 6952127820423161915}
+  - {fileID: 6934483369034327977}
   m_Father: {fileID: -4332445788766981374}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -101,6 +376,37 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!1 &4059407076714638506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6934483369034327977}
+  m_Layer: 0
+  m_Name: Regen Bar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6934483369034327977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4059407076714638506}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.19, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 849168559200411071}
+  m_Father: {fileID: 1283021409805530943}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4948749012880811816
 GameObject:
   m_ObjectHideFlags: 0
@@ -426,11 +732,14 @@ MonoBehaviour:
   - {fileID: 2909255494181278885}
   - {fileID: 3055286999774034445}
   - {fileID: 3383819029546123249}
+  healthPickupGameObj: {fileID: 6062236654396820198, guid: b5c31f18ad4a0d842921ebed85f2c883, type: 3}
   staminaMax: 100
   stamina: 100
   staminaRechargeRate: 2
   staminaBar: {fileID: 8726192590555423247}
   ammoBar: {fileID: 832614831945798190}
+  killRegen: 0
+  killRegenBar: {fileID: 849168559200411068}
 --- !u!50 &7045101813800168214
 Rigidbody2D:
   serializedVersion: 4
@@ -551,8 +860,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   equipSound: {fileID: 0}
-  meleeWeapon: {fileID: 11400000, guid: bb95e8d715184684dabd602a0b99e460, type: 2}
-  rangeWeapon: {fileID: 11400000, guid: 4538b90e706b0fd499ed092b5259c033, type: 2}
+  meleeWeaponClass: 0
+  rangedWeaponClass: 0
+  damageTable: {fileID: 0}
+  projectileLifeTimesTable: {fileID: 0}
+  rangedWeaponSpritesTable: {fileID: 0}
+  projectilePrefabTable: {fileID: 0}
+  bulletTemplate: {fileID: 0}
+  tables: {fileID: 0}
 --- !u!114 &7045101813800168208
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -625,8 +940,8 @@ MonoBehaviour:
   chainTime: 4
   attackSpeedBoost: 2
   speedBoost: 2
-  meleeWeapon: {fileID: 0}
-  rangedWeapon: {fileID: 0}
+  melee: 0
+  ranged: 0
   meleeDamageAddition: 0
   meleeDamageMultiplier: 1
   rangedDamageAddition: 0
@@ -878,6 +1193,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8069da242dd289f4ab690c63c53f3819, type: 3}
+--- !u!4 &1363825708522313754 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 522256626616059444, guid: 8069da242dd289f4ab690c63c53f3819, type: 3}
+  m_PrefabInstance: {fileID: 1572360876979117614}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8726192590555423247 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7839513570453519393, guid: 8069da242dd289f4ab690c63c53f3819, type: 3}
@@ -889,11 +1209,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1363825708522313754 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 522256626616059444, guid: 8069da242dd289f4ab690c63c53f3819, type: 3}
-  m_PrefabInstance: {fileID: 1572360876979117614}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4431020195500690291
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Killing entities adds to a meter.
When the meter is full, a health pickup is dropped.

Further adjustments and design decisions will be made to tweak this mechanic later on.